### PR TITLE
Add AppVeyor build; Ensure AppVeyor branch-build numbers are unique

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,0 +1,16 @@
+os: Visual Studio 2019
+
+# Build script
+build_script:
+  - ps: .\build.ps1
+
+# Tests
+test: off
+
+artifacts:
+  - path: artifacts\nuget-package\*.nupkg
+  - path: artifacts\nuget-package\*.snupkg
+
+environment:
+  # Skip dotnet package caching on build servers
+  DOTNET_SKIP_FIRST_TIME_EXPERIENCE: true

--- a/build.cake
+++ b/build.cake
@@ -140,23 +140,24 @@ Task("__UpdateAssemblyVersionInformation")
 
     Information("");
     Information("Obtained raw version info for package versioning:");
-    Information("NuGetVersion -> {0}", gitVersionOutput["NuGetVersion"]);
-    Information("FullSemVer -> {0}", gitVersionOutput["FullSemVer"]);
-    Information("AssemblySemVer -> {0}", gitVersionOutput["AssemblySemVer"]);
+    Information("NuGetVersion                 -> {0}", gitVersionOutput["NuGetVersion"]);
+    Information("FullSemVer                   -> {0}", gitVersionOutput["FullSemVer"]);
+    Information("AssemblySemVer               -> {0}", gitVersionOutput["AssemblySemVer"]);
+    Information("Major                        -> {0}", gitVersionOutput["Major"]);
 
     appveyorBuildNumber = gitVersionOutput["BranchName"].ToString().Equals("master", StringComparison.OrdinalIgnoreCase)
         ? gitVersionOutput["FullSemVer"].ToString() 
-        : gitVersionOutput["InformationalVersion"].ToString();
+        : $"{gitVersionOutput["InformationalVersion"]}-{DateTime.UtcNow.ToString("yyyyMMddHHmmssffff")}";
     nugetVersion = gitVersionOutput["NuGetVersion"].ToString();
     assemblyVersion = gitVersionOutput["Major"].ToString() + ".0.0.0";
     assemblySemver = gitVersionOutput["AssemblySemVer"].ToString();
 
     Information("");
     Information("Mapping versioning information to:");
-    Information("Appveyor build number -> {0}", appveyorBuildNumber);
-    Information("Nuget package version -> {0}", nugetVersion);
-    Information("AssemblyVersion -> {0}", assemblyVersion);
-    Information("AssemblyFileVersion -> {0}", assemblySemver);
+    Information("Appveyor build number        -> {0}", appveyorBuildNumber);
+    Information("Nuget package version        -> {0}", nugetVersion);
+    Information("AssemblyVersion              -> {0}", assemblyVersion);
+    Information("AssemblyFileVersion          -> {0}", assemblySemver);
     Information("AssemblyInformationalVersion -> {0}", assemblySemver);
 });
 


### PR DESCRIPTION
Ensures that the AppVeyor build number for branch builds will be unique.

Intentionally does not apply the same fix to `master`-branch build numbers; the `master`-branch does not tend to build twice per commit, and `FullSemVer` is sufficient for those builds.